### PR TITLE
Add api_servers_ips input variable for IP SAN

### DIFF
--- a/tls-k8s.tf
+++ b/tls-k8s.tf
@@ -74,7 +74,8 @@ resource "tls_cert_request" "apiserver" {
   ]
 
   ip_addresses = [
-    "${cidrhost(var.service_cidr, 1)}",
+    "${compact(distinct(list(cidrhost(var.service_cidr, 1)),
+                                      var.api_servers_ips))}"
   ]
 }
 

--- a/tls-k8s.tf
+++ b/tls-k8s.tf
@@ -74,8 +74,8 @@ resource "tls_cert_request" "apiserver" {
   ]
 
   ip_addresses = [
-    "${compact(distinct(list(cidrhost(var.service_cidr, 1)),
-                                      var.api_servers_ips))}"
+    "${cidrhost(var.service_cidr, 1)}",
+    "${var.api_servers_ips}",
   ]
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -8,6 +8,12 @@ variable "api_servers" {
   type        = "list"
 }
 
+variable "api_servers_ips" {
+  description = "IPs used to reach kube-apiserver."
+  type        = "list"
+  default     = []
+}
+
 variable "etcd_servers" {
   description = "List of etcd server URLs including protocol, host, and port. Ignored if experimental self-hosted etcd is enabled."
   type        = "list"


### PR DESCRIPTION
My use-case is to make temporary clusters for CI easier to automate. Also it's an option that is missing for parity with bootkube.

Thanks for creating this project!