### PR TITLE
Update assets generation for bootkube v0.6.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
 # bootkube-terraform
 
-`bootkube-terraform` is a Terraform module that renders [bootkube](https://github.com/kubernetes-incubator/bootkube) assets, just like running the binary `bootkube render`. It aims to provide the same variable names, defaults, features, and outputs.
+`bootkube-terraform` is Terraform module that renders [kubernetes-incubator/bootkube](https://github.com/kubernetes-incubator/bootkube) bootstrapping assets. It functions as a low-level component of the [Typhoon](https://github.com/poseidon/typhoon) Kubernetes distribution.
+
+The module provides many of the same variable names, defaults, features, and outputs as running `bootkube render` directly.
 
 ## Usage
 
-Use the `bootkube-terraform` module within your existing Terraform configs. Provide the variables listed in `variables.tf` or check `terraform.tfvars.example` for examples.
+Use [Typhoon](https://github.com/poseidon/typhoon) to create and manage Kubernetes clusters in different environments. Use `bootkube-terraform` if you require low-level customizations to the control plane or wish to build your own distribution.
+
+Add the `bootkube-terraform` module alongside existing Terraform configs. Provide the variables listed in `variables.tf` or check `terraform.tfvars.example` for examples.
 
 ```hcl
 module "bootkube" {
@@ -30,7 +34,7 @@ terraform apply
 
 ### Comparison
 
-Render bootkube assets directly with bootkube v0.6.1.
+Render bootkube assets directly with bootkube v0.6.2.
 
 #### On-host etcd
 
@@ -41,6 +45,9 @@ bootkube render --asset-dir=assets --api-servers=https://node1.example.com:443 -
 Compare assets. The only diffs you should see are TLS credentials.
 
 ```sh
+pushd /home/core/mycluster
+mv manifests-networking/* manifests
+popd
 diff -rw assets /home/core/mycluster
 ```
 
@@ -56,6 +63,7 @@ Compare assets. Note that experimental must be generated to a separate directory
 pushd /home/core/mycluster
 mv experimental/bootstrap-manifests/* boostrap-manifests
 mv experimental/manifests/* manifests
+mv manifests-networking/* manifests
 popd
 diff -rw assets /home/core/mycluster
 ```

--- a/resources/etcd/migrate-etcd-cluster.json
+++ b/resources/etcd/migrate-etcd-cluster.json
@@ -1,6 +1,6 @@
 {
-  "apiVersion": "etcd.coreos.com/v1beta1",
-  "kind": "Cluster",
+  "apiVersion": "etcd.database.coreos.com/v1beta2",
+  "kind": "EtcdCluster",
   "metadata": {
     "name": "kube-etcd",
     "namespace": "kube-system"

--- a/resources/experimental/manifests/etcd-operator.yaml
+++ b/resources/experimental/manifests/etcd-operator.yaml
@@ -19,10 +19,10 @@ spec:
     spec:
       containers:
       - name: etcd-operator
-        image: quay.io/coreos/etcd-operator:v0.4.2
+        image: quay.io/coreos/etcd-operator:v0.5.0
         command:
-          - /usr/local/bin/etcd-operator
-          - --analytics=false
+        - /usr/local/bin/etcd-operator
+        - --analytics=false
         env:
         - name: MY_POD_NAMESPACE
           valueFrom:

--- a/resources/flannel/kube-flannel.yaml
+++ b/resources/flannel/kube-flannel.yaml
@@ -40,7 +40,7 @@ spec:
         - name: flannel-cfg
           mountPath: /etc/kube-flannel/
       - name: install-cni
-        image: quay.io/coreos/flannel-cni:0.1.0
+        image: quay.io/coreos/flannel-cni:v0.2.0
         command: ["/install-cni.sh"]
         env:
         - name: CNI_NETWORK_CONFIG

--- a/resources/manifests/kube-apiserver.yaml
+++ b/resources/manifests/kube-apiserver.yaml
@@ -82,6 +82,6 @@ spec:
         hostPath:
           path: /var/lock
   updateStrategy:
-      rollingUpdate:
-        maxUnavailable: 1
-      type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate

--- a/resources/manifests/pod-checkpointer.yaml
+++ b/resources/manifests/pod-checkpointer.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: pod-checkpointer
-        image: quay.io/coreos/pod-checkpointer:4e7a7dab10bc4d895b66c21656291c6e0b017248
+        image: quay.io/coreos/pod-checkpointer:0cd390e0bc1dcdcc714b20eda3435c3d00669d0e
         command:
         - /checkpoint
         - --v=4

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -2,4 +2,5 @@ cluster_name = "example"
 api_servers = ["node1.example.com"]
 etcd_servers = ["node1.example.com"]
 asset_dir = "/home/core/mycluster"
+networking = "flannel"
 experimental_self_hosted_etcd = false

--- a/variables.tf
+++ b/variables.tf
@@ -62,7 +62,7 @@ variable "container_images" {
   type        = "map"
 
   default = {
-    hyperkube = "quay.io/coreos/hyperkube:v1.7.3_coreos.0"
+    hyperkube = "quay.io/coreos/hyperkube:v1.7.5_coreos.0"
     etcd      = "quay.io/coreos/etcd:v3.1.8"
   }
 }


### PR DESCRIPTION
* Update hyperkube to v1.7.5_coreos.0
* Update etcd-operator to v0.5.0
* Update pod-checkpointer
* Update flannel-cni to v0.2.0
* Change etcd-operator TPR to CRD

rel: https://github.com/kubernetes-incubator/bootkube/releases/tag/v0.6.2