### PR TITLE
Extract api server port from api_servers list like bootkube

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ module "bootkube" {
   source = "git://https://github.com/dghubble/bootkube-terraform.git?ref=SHA"
 
   cluster_name = "example"
-  api_servers = ["node1.example.com"]
+  api_servers = ["https://node1.example.com:6443"]
   etcd_servers = ["node1.example.com"]
   asset_dir = "/home/core/clusters/mycluster"
   experimental_self_hosted_etcd = false
@@ -39,7 +39,7 @@ Render bootkube assets directly with bootkube v0.6.2.
 #### On-host etcd
 
 ```sh
-bootkube render --asset-dir=assets --api-servers=https://node1.example.com:443 --api-server-alt-names=DNS=node1.example.com --etcd-servers=https://node1.example.com:2379
+bootkube render --asset-dir=assets --api-servers=https://node1.example.com:6443 --api-server-alt-names=DNS=node1.example.com --etcd-servers=https://node1.example.com:2379
 ```
 
 Compare assets. The only diffs you should see are TLS credentials.
@@ -54,7 +54,7 @@ diff -rw assets /home/core/mycluster
 #### Self-hosted etcd
 
 ```sh
-bootkube render --asset-dir=assets --api-servers=https://node1.example.com:443 --api-server-alt-names=DNS=node1.example.com --experimental-self-hosted-etcd
+bootkube render --asset-dir=assets --api-servers=https://node1.example.com:6443 --api-server-alt-names=DNS=node1.example.com --experimental-self-hosted-etcd
 ```
 
 Compare assets. Note that experimental must be generated to a separate directory for terraform applies to sync. Move the experimental `bootstrap-manifests` and `manifests` files during deployment.
@@ -67,4 +67,3 @@ mv manifests-networking/* manifests
 popd
 diff -rw assets /home/core/mycluster
 ```
-

--- a/assets.tf
+++ b/assets.tf
@@ -6,7 +6,7 @@ resource "template_dir" "bootstrap-manifests" {
   vars {
     hyperkube_image = "${var.container_images["hyperkube"]}"
     etcd_servers    = "${var.experimental_self_hosted_etcd ? format("https://%s:2379,https://127.0.0.1:12379", cidrhost(var.service_cidr, 15)) : join(",", formatlist("https://%s:2379", var.etcd_servers))}"
-
+    api_port        = "${replace(element(var.api_servers, 0), "/.*:([0-9]+)[/]?$/", "$1") == element(var.api_servers, 0) ? "443" : replace(element(var.api_servers, 0), "/.*:([0-9]+)[/]?$/", "$1")}"
     cloud_provider = "${var.cloud_provider}"
     pod_cidr       = "${var.pod_cidr}"
     service_cidr   = "${var.service_cidr}"
@@ -21,7 +21,7 @@ resource "template_dir" "manifests" {
   vars {
     hyperkube_image = "${var.container_images["hyperkube"]}"
     etcd_servers    = "${var.experimental_self_hosted_etcd ? format("https://%s:2379", cidrhost(var.service_cidr, 15)) : join(",", formatlist("https://%s:2379", var.etcd_servers))}"
-
+    api_port        = "${replace(element(var.api_servers, 0), "/.*:([0-9]+)[/]?$/", "$1") == element(var.api_servers, 0) ? "443" : replace(element(var.api_servers, 0), "/.*:([0-9]+)[/]?$/", "$1")}"
     cloud_provider      = "${var.cloud_provider}"
     pod_cidr            = "${var.pod_cidr}"
     service_cidr        = "${var.service_cidr}"
@@ -58,7 +58,7 @@ data "template_file" "kubeconfig" {
     ca_cert      = "${base64encode(var.ca_certificate == "" ? join(" ", tls_self_signed_cert.kube-ca.*.cert_pem) : var.ca_certificate)}"
     kubelet_cert = "${base64encode(tls_locally_signed_cert.kubelet.cert_pem)}"
     kubelet_key  = "${base64encode(tls_private_key.kubelet.private_key_pem)}"
-    server       = "${format("https://%s:443", element(var.api_servers, 0))}"
+    server       = "${element(var.api_servers, 0)}"
   }
 }
 
@@ -70,6 +70,6 @@ data "template_file" "user-kubeconfig" {
     ca_cert      = "${base64encode(var.ca_certificate == "" ? join(" ", tls_self_signed_cert.kube-ca.*.cert_pem) : var.ca_certificate)}"
     kubelet_cert = "${base64encode(tls_locally_signed_cert.kubelet.cert_pem)}"
     kubelet_key  = "${base64encode(tls_private_key.kubelet.private_key_pem)}"
-    server       = "${format("https://%s:443", element(var.api_servers, 0))}"
+    server       = "${element(var.api_servers, 0)}"
   }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -69,5 +69,5 @@ output "kubelet_key" {
 }
 
 output "server" {
-  value = "${format("https://%s:443", element(var.api_servers, 0))}"
+  value = "${element(var.api_servers, 0)}"
 }

--- a/resources/bootstrap-manifests/bootstrap-apiserver.yaml
+++ b/resources/bootstrap-manifests/bootstrap-apiserver.yaml
@@ -26,7 +26,7 @@ spec:
     - --insecure-port=0
     - --kubelet-client-certificate=/etc/kubernetes/secrets/apiserver.crt
     - --kubelet-client-key=/etc/kubernetes/secrets/apiserver.key
-    - --secure-port=443
+    - --secure-port=${api_port}
     - --service-account-key-file=/etc/kubernetes/secrets/service-account.pub
     - --service-cluster-ip-range=${service_cidr}
     - --cloud-provider=${cloud_provider}

--- a/resources/manifests/kube-apiserver.yaml
+++ b/resources/manifests/kube-apiserver.yaml
@@ -40,7 +40,7 @@ spec:
         - --insecure-port=0
         - --kubelet-client-certificate=/etc/kubernetes/secrets/apiserver.crt
         - --kubelet-client-key=/etc/kubernetes/secrets/apiserver.key
-        - --secure-port=443
+        - --secure-port=${api_port}
         - --service-account-key-file=/etc/kubernetes/secrets/service-account.pub
         - --service-cluster-ip-range=${service_cidr}
         - --storage-backend=etcd3

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -1,5 +1,5 @@
 cluster_name = "example"
-api_servers = ["node1.example.com"]
+api_servers = ["https://node1.example.com:443"]
 etcd_servers = ["node1.example.com"]
 asset_dir = "/home/core/mycluster"
 networking = "flannel"

--- a/tls-k8s.tf
+++ b/tls-k8s.tf
@@ -66,7 +66,7 @@ resource "tls_cert_request" "apiserver" {
   }
 
   dns_names = [
-    "${var.api_servers}",
+    "${split(",",replace(join(",",var.api_servers),"/https?:[/]{2}([^,:]+)(:[0-9]+)?/","$1"))}",
     "kubernetes",
     "kubernetes.default",
     "kubernetes.default.svc",


### PR DESCRIPTION
Checked with a diff between configuration files generate from bootkube-terraform and bootkube like said in the readme file (that i have update for the occasion)